### PR TITLE
Update EmailComposerProxy.js

### DIFF
--- a/src/windows/EmailComposerProxy.js
+++ b/src/windows/EmailComposerProxy.js
@@ -255,8 +255,9 @@ exports.getUriForResourcePath = function (path) {
  *      The URI including the given content
  */
 exports.getUriForBase64Content = function (content) {
-    var base64 = content.replace('base64:icon.png//', ''),
-        name   = content.match(/^base64:([^\/]+)/)[1],
+    var match = content.match(/^base64:([^\/]+)\/\/(.*)/),
+        base64 = match[2],
+        name = match[1],
         buffer = Windows.Security.Cryptography.CryptographicBuffer.decodeFromBase64String(base64),
         rwplus = Windows.Storage.CreationCollisionOption.openIfExists,
         folder = Windows.Storage.ApplicationData.current.temporaryFolder,


### PR DESCRIPTION
Fixed issue where getting base64 content only worked for files with the file name of 'icon.png'.
now works with all file names.