### PR TITLE
Fix: original app crashes upon return on specific Android + email app

### DIFF
--- a/src/android/EmailComposer.java
+++ b/src/android/EmailComposer.java
@@ -164,7 +164,9 @@ public class EmailComposer extends CordovaPlugin {
      */
     @Override
     public void onActivityResult(int reqCode, int resCode, Intent intent) {
-        command.success();
+        if (null != command) {
+            command.success();   
+        }
     }
 
 }


### PR DESCRIPTION
Tested on LG D605 (a.k.a. LG Optimus L9 II) with Android 4.1.2. Possibly an issue caused by resource management on phones with lower specs? Going to mail app from original app removes original app from "cache", making command attribute (see code) null --> NullPointerException. As app is no longer is in "cache", it has to be reloaded entirely anyway, so there's no use in running command.success() callback. This fix ensures there is no crash with "Unfortunately, <my app> has stopped".