### PR TITLE
Fix iOS crash when no email is set up, caused by isAvailable falsely returning True

### DIFF
--- a/src/ios/APPEmailComposerImpl.m
+++ b/src/ios/APPEmailComposerImpl.m
@@ -58,8 +58,6 @@
 
     if (TARGET_IPHONE_SIMULATOR && [scheme hasPrefix:@"mailto:"]) {
         canSendMail = true;
-    } else {
-        canSendMail = canSendMail||withScheme;
     }
     
     NSArray* resultArray = [NSArray arrayWithObjects:@(canSendMail),@(withScheme), nil];


### PR DESCRIPTION
The problem and way the crash occurs can be seen in this issue: https://github.com/katzer/cordova-plugin-email-composer/issues/122

This else case hides the fact that canSendMail is FALSE. 

canSendMail is being set to false, but withScheme is true - There is no reason to OR these two together because the function returns a boolean array with both Bools in it anyways. 

Removing this else condition makes it so that isAvailable properly returns false and causes no device crashes.