### PR TITLE
Add email sending or cancel status ios

### DIFF
--- a/src/ios/APPEmailComposer.m
+++ b/src/ios/APPEmailComposer.m
@@ -98,7 +98,7 @@
             if (TARGET_IPHONE_SIMULATOR && !IsAtLeastiOSVersion(@"8.3"))
             {
                 [self informAboutIssueWithSimulators];
-                [self execCallback];
+                [self execCallback: NO];
                 return;
             }
             else
@@ -127,7 +127,7 @@
 {
     [controller dismissViewControllerAnimated:YES completion:nil];
 
-    [self execCallback];
+    [self execCallback: result == MFMailComposeResultSent];
 }
 
 #pragma mark -
@@ -191,11 +191,11 @@
 /**
  * Invokes the callback without any parameter.
  */
-- (void) execCallback
+- (void) execCallback:(BOOL) sent
 {
     CDVPluginResult *result = [CDVPluginResult
-                               resultWithStatus:CDVCommandStatus_OK];
-
+                               resultWithStatus:CDVCommandStatus_OK messageAsBool:sent];
+    
     [self.commandDelegate sendPluginResult:result
                                 callbackId:_command.callbackId];
 }

--- a/src/ios/APPEmailComposerImpl.m
+++ b/src/ios/APPEmailComposerImpl.m
@@ -56,11 +56,11 @@
     withScheme = [[UIApplication sharedApplication]
                    canOpenURL:url];
 
-    if (TARGET_IPHONE_SIMULATOR && [scheme hasPrefix:@"mailto:"]) {
+    /*if (TARGET_IPHONE_SIMULATOR && [scheme hasPrefix:@"mailto:"]) {
         canSendMail = true;
     } else {
         canSendMail = canSendMail||withScheme;
-    }
+    }*/
     
     NSArray* resultArray = [NSArray arrayWithObjects:@(canSendMail),@(withScheme), nil];
 


### PR DESCRIPTION
when user close the email controller in iOS, the callback will tell the email is sent or cancelled.

Thanks