### PR TITLE
Fix to iOS and Android check of whether the native device can send mail.

### DIFF
--- a/src/android/EmailComposerImpl.java
+++ b/src/android/EmailComposerImpl.java
@@ -97,8 +97,7 @@ public class EmailComposerImpl {
         //is possible with specified app
         boolean withScheme = isAppInstalled(id, ctx);
         //is possible in general
-        boolean isPossible = isEmailAccountConfigured(ctx)||
-                withScheme;
+        boolean isPossible = isEmailAccountConfigured(ctx);
         boolean[] result = {isPossible,withScheme};
 
         return result;

--- a/src/ios/APPEmailComposerImpl.m
+++ b/src/ios/APPEmailComposerImpl.m
@@ -58,8 +58,6 @@
 
     if (TARGET_IPHONE_SIMULATOR && [scheme hasPrefix:@"mailto:"]) {
         canSendMail = true;
-    } else {
-        canSendMail = canSendMail||withScheme;
     }
     
     NSArray* resultArray = [NSArray arrayWithObjects:@(canSendMail),@(withScheme), nil];


### PR DESCRIPTION
This is in response to issue #131 (App crashes when trying to open email composer without any accounts set up)

In addition to the fix for iOS to ensure that canSendMail doesn't always return true I have made the corresponding change to the Android version of plugin. 

