### PR TITLE
using the account name as a reference to check email account types

### DIFF
--- a/src/android/EmailComposerImpl.java
+++ b/src/android/EmailComposerImpl.java
@@ -34,6 +34,7 @@ import android.net.Uri;
 import android.text.Html;
 import android.util.Base64;
 import android.util.Log;
+import android.util.Patterns;
 
 import org.json.JSONArray;
 import org.json.JSONException;
@@ -45,6 +46,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
 import java.util.ArrayList;
+import java.util.regex.Pattern;
 
 import static de.appplant.cordova.emailcomposer.EmailComposer.LOG_TAG;
 
@@ -514,8 +516,9 @@ public class EmailComposerImpl {
         AccountManager am  = AccountManager.get(ctx);
 
         try {
+            Pattern emailPattern = Patterns.EMAIL_ADDRESS;
             for (Account account : am.getAccounts()) {
-                if (account.type.endsWith("mail")) {
+                if (emailPattern.matcher(account.name).matches()) {
                     return true;
                 }
             }


### PR DESCRIPTION
When testing on Android 6.0, the `cordova.plugins.email.isAvailable` always returned false.
Nevertheless, I had several email clients installed (GMail, Outlook, K9-Mail).

The type of the account associated with the GMail accounts is `com.google`.
Therefore, I thought that it would be better to test the account name instead of the account type.
