### PR TITLE
Default schema to 'mailto:' if null (Simulator)

### DIFF
--- a/src/ios/APPEmailComposerImpl.m
+++ b/src/ios/APPEmailComposerImpl.m
@@ -48,8 +48,10 @@
 {
     bool canSendMail = [MFMailComposeViewController canSendMail];
     bool withScheme  = false;
-    
-    if (![scheme hasSuffix:@":"]) {
+   
+    if(scheme == [NSNull null]) {
+        scheme = @"mailto:";
+    } else if (![scheme hasSuffix:@":"]) {
         scheme = [scheme stringByAppendingString:@":"];
     }
     


### PR DESCRIPTION
Running this method on a device without mail account setup, scheme would show up as NSNull, thus crashing on if (![scheme hasSuffix:@":"]),
I simply default it to 'mailto:' if sheme is null.
