### PR TITLE
Fixes issue with detecting mail account

### DIFF
--- a/src/android/EmailComposerImpl.java
+++ b/src/android/EmailComposerImpl.java
@@ -45,6 +45,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
 import java.util.ArrayList;
+import java.util.regex.Pattern;
 
 import static de.appplant.cordova.emailcomposer.EmailComposer.LOG_TAG;
 
@@ -514,8 +515,9 @@ public class EmailComposerImpl {
         AccountManager am  = AccountManager.get(ctx);
 
         try {
+            Pattern mailPattern = Patterns.EMAIL_ADDRESS;
             for (Account account : am.getAccounts()) {
-                if (account.type.endsWith("mail")) {
+                if (mailPattern.matcher(account.name).matches()) {
                     return true;
                 }
             }

--- a/src/android/EmailComposerImpl.java
+++ b/src/android/EmailComposerImpl.java
@@ -46,6 +46,7 @@ import java.io.InputStream;
 import java.io.OutputStream;
 import java.util.ArrayList;
 import java.util.regex.Pattern;
+import android.util.Patterns;
 
 import static de.appplant.cordova.emailcomposer.EmailComposer.LOG_TAG;
 


### PR DESCRIPTION
Previous implementation expected that account **type** ends with string "mail". This doesn't seem to work, or at least it doesn't seem to work always. The fix tests if account **name** is a valid email address.
