### PR TITLE
Enhanced callback to check status of email sending process in iOS

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -24,7 +24,7 @@
 <plugin xmlns="http://apache.org/cordova/ns/plugins/1.0"
         xmlns:android="http://schemas.android.com/apk/res/android"
         id="cordova-plugin-email-composer"
-        version="0.8.3">
+        version="0.9.0">
 
     <name>EmailComposer</name>
 

--- a/src/ios/APPEmailComposer.m
+++ b/src/ios/APPEmailComposer.m
@@ -19,6 +19,12 @@
  under the License.
  */
 
+#define RETURN_CODE_EMAIL_CANCELLED 0
+#define RETURN_CODE_EMAIL_SAVED 1
+#define RETURN_CODE_EMAIL_SENT 2
+#define RETURN_CODE_EMAIL_FAILED 3
+#define RETURN_CODE_EMAIL_NOTSENT 4
+
 #import "APPEmailComposer.h"
 #import "APPEmailComposerImpl.h"
 #import <Cordova/CDVAvailability.h>
@@ -96,7 +102,7 @@
 
         if (TARGET_IPHONE_SIMULATOR) {
             [self informAboutIssueWithSimulators];
-            [self execCallback];
+            [self execCallback:RETURN_CODE_EMAIL_SENT];
         }
         else {
             [self presentMailComposerFromProperties:props];
@@ -109,15 +115,36 @@
 
 /**
  * Delegate will be called after the mail composer did finish an action
- * to dismiss the view.
+ * to dismiss the view and check for result.
  */
 - (void) mailComposeController:(MFMailComposeViewController*)controller
            didFinishWithResult:(MFMailComposeResult)result
                          error:(NSError*)error
 {
+
+    int code = 0;
+    
+    switch (result) {
+        case MFMailComposeResultCancelled:
+            code = RETURN_CODE_EMAIL_CANCELLED;
+            break;
+        case MFMailComposeResultSaved:
+            code = RETURN_CODE_EMAIL_SAVED;
+            break;
+        case MFMailComposeResultSent:
+            code = RETURN_CODE_EMAIL_SENT;
+            break;
+        case MFMailComposeResultFailed:
+            code = RETURN_CODE_EMAIL_FAILED;
+            break;
+        default:
+            code = RETURN_CODE_EMAIL_NOTSENT;
+            break;
+    }
+
     [controller dismissViewControllerAnimated:YES completion:NULL];
 
-    [self execCallback];
+    [self execCallback:code];
 }
 
 #pragma mark -
@@ -184,12 +211,13 @@
 }
 
 /**
- * Invokes the callback without any parameter.
+ * Invokes the callback.
  */
-- (void) execCallback
+- (void) execCallback:(int)code
 {
     CDVPluginResult *result = [CDVPluginResult
-                               resultWithStatus:CDVCommandStatus_OK];
+                               resultWithStatus:CDVCommandStatus_OK
+                                messageAsInt:code];
 
     [self.commandDelegate sendPluginResult:result
                                 callbackId:_command.callbackId];


### PR DESCRIPTION
Added status codes to the callback that will return one of them depending on the result of the email sending, in iOS. The options are: cancelled, saved, sent, failed, not sent. This feature gives a valuable feedback to the user.
Changes made to AppEmailComoser.m and plugin.xml files.
