### PR TITLE
Altered windows require id

### DIFF
--- a/src/windows/EmailComposerProxyImpl.js
+++ b/src/windows/EmailComposerProxyImpl.js
@@ -19,7 +19,7 @@ specific language governing permissions and limitations
 under the License.
 */
 
-var proxy = require('de.appplant.cordova.plugin.email-composer.EmailComposerProxy'),
+var proxy = require('cordova-plugin-email-composer.EmailComposerProxy'),
     impl  = proxy.impl = {},
     WinMail = Windows.ApplicationModel.Email;
 


### PR DESCRIPTION
Currently when you attempt to run a Windows Universal Cordova project, it crashes on start when it attempts to load the plugin modules:

![module error](http://i.imgur.com/cbPDVOV.png)
![available modules](http://i.imgur.com/1BQ2O3W.png)
