### PR TITLE
Set requirement for cordova-android engine

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -43,6 +43,7 @@
 
     <engines>
         <engine name="cordova" version=">=3.0.0" />
+        <engine name="cordova-android" version=">=3.7.0" />
     </engines>
 
     <!-- interface -->


### PR DESCRIPTION
Version 0.8.3 of the email composer plugin [uses a constructor](https://github.com/katzer/cordova-plugin-email-composer/blob/master/src/android/EmailComposer.java#L121) for the class PluginResult which was introduced in Cordova-android 3.7.0 with [this commit](https://github.com/Icenium/cordova-android/commit/fbeb379f1b2102d9d0739f92340c932bdc47873b)

Ping @katzer for review and possible merge
