### PR TITLE
canSendMail() returns incorrect ordering of flags

### DIFF
--- a/src/android/EmailComposerImpl.java
+++ b/src/android/EmailComposerImpl.java
@@ -99,7 +99,7 @@ public class EmailComposerImpl {
         // is possible in general
         boolean isPossible = isEmailAccountConfigured(ctx);
 
-        return new boolean[] { isPossible, withScheme };
+        return new boolean[] { withScheme, isPossible };
     }
 
     /**


### PR DESCRIPTION
As mentioned here - https://github.com/hunnysharma102/cordova-plugin-email-composer/commit/babebdd6fa4ba790380e8ce0155dea6a1d4630da - this is necessary for me to use the plugin at all. I have several email apps installed and have no issues with the plugin with this change.