### PR TITLE
Apply URL encoding when constructing mailto: link

### DIFF
--- a/src/browser/EmailComposerProxy.js
+++ b/src/browser/EmailComposerProxy.js
@@ -41,7 +41,7 @@ exports.isAvailable = function (success, error, args) {
  */
 exports.open = function (success, error, args) {
     var props   = args[0],
-        mailto  = 'mailto:' + props.to,
+        mailto  = 'mailto:' + encodeURIComponent(props.to),
         options = '';
 
     if (props.subject !== '') {

--- a/src/browser/EmailComposerProxy.js
+++ b/src/browser/EmailComposerProxy.js
@@ -45,23 +45,23 @@ exports.open = function (success, error, args) {
         options = '';
 
     if (props.subject !== '') {
-        options = options + '&subject=' + props.subject;
+        options += '&subject=' + encodeURIComponent(props.subject);
     }
 
     if (props.body !== '') {
-        options = options + '&body=' + props.body;
+        options += '&body=' + encodeURIComponent(props.body);
     }
 
     if (props.cc !== '') {
-        options = options + '&cc=' + props.cc;
+        options += '&cc=' + encodeURIComponent(props.cc);
     }
 
     if (props.bcc !== '') {
-        options = options + '&bcc=' + props.bcc;
+        options += '&bcc=' + encodeURIComponent(props.bcc);
     }
 
     if (options !== '') {
-        mailto = mailto + '?' + options.substring(1);
+        mailto += '?' + options.substring(1);
     }
 
     window.location.href = mailto;


### PR DESCRIPTION
Otherwise, newlines and other characters get dropped.