### PR TITLE
To provide more provider paths in Android

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -101,11 +101,13 @@
         <config-file target="AndroidManifest.xml" parent="/manifest">
             <uses-permission android:name="android.permission.GET_ACCOUNTS" />
         </config-file>
-
+        <config-file target="AndroidManifest.xml" parent="/*">
+            <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE" />
+        </config-file>
         <config-file target="AndroidManifest.xml" parent="application">
             <provider
                 android:name="de.appplant.cordova.emailcomposer.Provider"
-                android:authorities="${applicationId}.provider"
+                android:authorities="${applicationId}.emailcomposer.provider"
                 android:exported="false"
                 android:grantUriPermissions="true" >
                 <meta-data

--- a/src/android/AssetUtil.java
+++ b/src/android/AssetUtil.java
@@ -268,7 +268,7 @@ final class AssetUtil {
      * @return content://...
      */
     private Uri getUriForFile(Context ctx, File file) {
-        String authority = ctx.getPackageName() + ".provider";
+        String authority = ctx.getPackageName() + ".emailcomposer.provider";
 
         try {
             return Provider.getUriForFile(ctx, authority, file);

--- a/src/android/xml/emailcomposer_provider_paths.xml
+++ b/src/android/xml/emailcomposer_provider_paths.xml
@@ -21,4 +21,14 @@
 
 <paths xmlns:android="http://schemas.android.com/apk/res/android">
     <external-path name="external_files" path="."/>
+    <!-- cordova.file.dataDirectory -->
+    <files-path name="files" path="." />
+    <!-- cordova.file.cacheDirectory -->
+    <cache-path name="cache" path="." />
+    <!-- cordova.file.externalDataDirectory -->
+    <external-files-path name="external-files" path="." />
+    <!-- cordova.file.externalCacheDirectory -->
+    <external-cache-path name="external-cache" path="." />
+    <!-- cordova.file.externalRootDirectory -->
+    <external-path name="external" path="." />
 </paths>


### PR DESCRIPTION
- Change the authority name to avoid conflicts with other plugins
- Add more paths in emailcomposer_provider_paths.xml so plugin will try to search files in more locations