### PR TITLE
Added ANDROID_SUPPORT_V4_VERSION

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -90,6 +90,8 @@
 
     <!-- android -->
     <platform name="android">
+        <preference name="ANDROID_SUPPORT_V4_VERSION" default="27.+"/>
+        <framework src="com.android.support:support-v4:$ANDROID_SUPPORT_V4_VERSION"/>
         <config-file target="config.xml" parent="/*">
             <feature name="EmailComposer">
                 <param name="android-package"


### PR DESCRIPTION
Added ANDROID_SUPPORT_V4_VERSION to avoid `error: package android.support.v4.content does not exist.` in Cordova Platforms     : android 7.1.4