### PR TITLE
Fix error: package android.support.v4.content does not exist

### DIFF
--- a/src/android/Provider.java
+++ b/src/android/Provider.java
@@ -19,7 +19,7 @@
 
 package de.appplant.cordova.emailcomposer;
 
-import android.support.v4.content.FileProvider;
+import androidx.core.content.FileProvider;
 
 public class Provider extends FileProvider {
     // Nothing to do here


### PR DESCRIPTION
This fix allows this plugin to build with no errors using Cordova Android 10.0.1. 
Tested on simulator only.