### PR TITLE
fix Android 11 email intent params & targets

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -93,6 +93,13 @@
         <preference name="ANDROID_SUPPORT_V4_VERSION" default="28.+"/>
         <framework src="com.android.support:support-v4:$ANDROID_SUPPORT_V4_VERSION"/>
 
+        <config-file target="app/src/main/AndroidManifest.xml" parent="/manifest/queries">
+            <intent>
+                <action android:name="android.intent.action.SENDTO" />
+                <data android:scheme="mailto" />
+            </intent>
+        </config-file>
+
         <config-file target="config.xml" parent="/*">
             <feature name="EmailComposer">
                 <param name="android-package"

--- a/src/android/Impl.java
+++ b/src/android/Impl.java
@@ -87,7 +87,7 @@ class Impl {
             targets.add(target.setPackage(clientId));
         }
 
-        return Intent.createChooser(draft, header)
+        return Intent.createChooser(targets.remove(0), header)
                 .putExtra(EXTRA_INITIAL_INTENTS, targets.toArray(new Parcelable[0]));
     }
 


### PR DESCRIPTION
Fixes Android 11 target sdk 30 crash, fixes email intent params and now can successfully attach multiple files, pop up menu shows the correct target apps.