### PR TITLE
Android 11 support

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -93,13 +93,11 @@
         <preference name="ANDROID_SUPPORT_V4_VERSION" default="28.+"/>
         <framework src="com.android.support:support-v4:$ANDROID_SUPPORT_V4_VERSION"/>
 
-        <config-file target="app/src/main/AndroidManifest.xml" parent="/manifest">
-            <queries>
-                <intent>
-                    <action android:name="android.intent.action.SENDTO" />
-                    <data android:scheme="mailto" />
-                </intent>
-            </queries>
+        <config-file target="app/src/main/AndroidManifest.xml" parent="/manifest/queries">
+            <intent>
+                <action android:name="android.intent.action.SENDTO" />
+                <data android:scheme="mailto" />
+            </intent>
         </config-file>
 
         <config-file target="config.xml" parent="/*">

--- a/plugin.xml
+++ b/plugin.xml
@@ -93,6 +93,15 @@
         <preference name="ANDROID_SUPPORT_V4_VERSION" default="28.+"/>
         <framework src="com.android.support:support-v4:$ANDROID_SUPPORT_V4_VERSION"/>
 
+        <config-file target="app/src/main/AndroidManifest.xml" parent="/manifest">
+            <queries>
+                <intent>
+                    <action android:name="android.intent.action.SENDTO" />
+                    <data android:scheme="mailto" />
+                </intent>
+            </queries>
+        </config-file>
+
         <config-file target="config.xml" parent="/*">
             <feature name="EmailComposer">
                 <param name="android-package"

--- a/src/android/Impl.java
+++ b/src/android/Impl.java
@@ -87,12 +87,6 @@ class Impl {
             targets.add(target.setPackage(clientId));
         }
 
-        if (targets.size() == 0) {
-            // Shouldn't happen
-            Log.w(LOG_TAG, "Device does not have any email client apps");
-            return draft;
-        }
-
         return Intent.createChooser(targets.remove(0), header)
                 .putExtra(EXTRA_INITIAL_INTENTS, targets.toArray(new Parcelable[0]));
     }

--- a/src/android/Impl.java
+++ b/src/android/Impl.java
@@ -87,6 +87,12 @@ class Impl {
             targets.add(target.setPackage(clientId));
         }
 
+        if (targets.size() == 0) {
+            // Shouldn't happen
+            Log.w(LOG_TAG, "Device does not have any email client apps");
+            return draft;
+        }
+
         return Intent.createChooser(targets.remove(0), header)
                 .putExtra(EXTRA_INITIAL_INTENTS, targets.toArray(new Parcelable[0]));
     }


### PR DESCRIPTION
Fixes #361

Android 11 restricts package visibility which causes the code to return 0 email clients.

https://developer.android.com/training/package-visibility/declaring#intent-filter-signature

This PR declares `query` for `SENDTO` action, to enable the ability to query for apps that register the `SENDTO` action